### PR TITLE
Add tests confirming genesis.json generation

### DIFF
--- a/gen/generate.go
+++ b/gen/generate.go
@@ -355,14 +355,10 @@ func generateGenesisFiles(protoVersion protocol.ConsensusVersion, protoParams co
 	}
 
 	sinkAcct := genesisAllocation{
-		Name:   "FeeSink",
-		Stake:  protoParams.MinBalance,
-		Online: basics.NotParticipating,
+		Name: "FeeSink",
 	}
 	poolAcct := genesisAllocation{
-		Name:   "RewardsPool",
-		Stake:  rewardsBalance,
-		Online: basics.NotParticipating,
+		Name: "RewardsPool",
 	}
 
 	alloc2 := make([]genesisAllocation, 0, len(allocation)+2)

--- a/gen/generate_test.go
+++ b/gen/generate_test.go
@@ -123,7 +123,7 @@ func TestGenesisRoundoff(t *testing.T) {
 
 // `TestGenesisJsonCreation` defends against regressions to `genesis.json` generation by comparing a known, valid `genesis.json` against a version generated during test invocation.
 //
-// * For each `testCase`, there is a corresponding `genesis.json` in `gen/resources representing the known, valid output.
+// * For each `testCase`, there is a corresponding `genesis.json` in `gen/resources` representing the known, valid output.
 // * When adding test cases, it's assumed folks peer review new artifacts in `gen/resources`.
 // * Since _some_ `genesis.json` values are non-deterministic, the test replaces these values with static values to facilitate equality checks.
 func TestGenesisJsonCreation(t *testing.T) {

--- a/gen/generate_test.go
+++ b/gen/generate_test.go
@@ -17,7 +17,13 @@
 package gen
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/algorand/go-algorand/crypto"
+	"github.com/algorand/go-algorand/data/bookkeeping"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -113,4 +119,117 @@ func TestGenesisRoundoff(t *testing.T) {
 	_, _, _, err := setupGenerateGenesisFiles(&genesisData, config.Consensus, &verbosity)
 	require.NoError(t, err)
 	require.True(t, strings.Contains(verbosity.String(), "roundoff"))
+}
+
+// `TestGenesisJsonCreation` defends against regressions to `genesis.json` generation by comparing a known, valid `genesis.json` against a version generated during test invocation.
+//
+// * For each `testCase`, there is a corresponding `genesis.json` in `gen/resources representing the known, valid output.
+// * When adding test cases, it's assumed folks peer review new artifacts in `gen/resources`.
+// * Since _some_ `genesis.json` values are non-deterministic, the test replaces these values with static values to facilitate equality checks.
+func TestGenesisJsonCreation(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	type testCase struct {
+		name string
+		gd   GenesisData
+	}
+
+	// `base` is a canonical test confirming `devnet.json` generates the intended `genesis.json`.
+	base := func() testCase {
+		jsonBytes, err := os.ReadFile("devnet.json")
+		require.NoError(t, err)
+
+		gd := DefaultGenesis
+		err = json.Unmarshal(jsonBytes, &gd)
+		require.NoError(t, err)
+
+		return testCase{"base", gd}
+	}
+
+	// `balance` extends `base` to confirm overriding the rewards pool balance works.
+	balance := func() testCase {
+		gd := base().gd
+		gd.RewardsPoolBalance = 0 // Expect generated balance == MinBalance
+		return testCase{"balance", gd}
+	}
+
+	// `blotOutRandomValues` replaces random values with static values to support equality checks.
+	blotOutRandomValues := func(as []bookkeeping.GenesisAllocation) {
+		deterministicAddresses := []string{"FeeSink", "RewardsPool"}
+
+		isNondeterministicAddress := func(name string) bool {
+			for _, address := range deterministicAddresses {
+				if name == address {
+					return false
+				}
+			}
+			return true
+		}
+
+		for i := range as {
+			require.Len(t, as[i].State.VoteID, 32)
+			as[i].State.VoteID = crypto.OneTimeSignatureVerifier{}
+			require.Len(t, as[i].State.VoteID, 32)
+			as[i].State.SelectionID = crypto.VRFVerifier{}
+
+			if isNondeterministicAddress(as[i].Comment) {
+				require.Len(t, as[i].Address, 58)
+				as[i].Address = ""
+			}
+		}
+	}
+
+	saveGeneratedGenesisJson := func(filename, artifactName string) {
+		src, err := os.Open(filename)
+		require.NoError(t, err)
+		defer src.Close()
+
+		dst, err := os.CreateTemp("", "*-"+artifactName)
+		require.NoError(t, err)
+		defer dst.Close()
+
+		_, err = io.Copy(dst, src)
+		require.NoError(t, err)
+
+		t.Log("generated genesis.json = " + dst.Name())
+	}
+
+	// Since `t.TempDir` deletes the generated dir, retain generated `genesis.json` on test failure.
+	saveOnFailure := func(result bool, generatedFilename, artifactName string) {
+		if !result {
+			saveGeneratedGenesisJson(generatedFilename, artifactName)
+			t.FailNow()
+		}
+	}
+
+	for _, tc := range []testCase{
+		base(),
+		balance(),
+	} {
+		t.Run(fmt.Sprintf("name=%v", tc.name), func(t *testing.T) {
+			gd := tc.gd
+			gd.LastPartKeyRound = 10 // Ensure quick test execution by reducing rounds.
+
+			outDir := t.TempDir()
+			err := GenerateGenesisFiles(gd, config.Consensus, outDir, nil)
+			require.NoError(t, err)
+
+			artifactName := fmt.Sprintf("genesis-%v.json", tc.name)
+			generatedFilename := fmt.Sprintf("%v/genesis.json", outDir)
+			saveOnFailure := func(result bool) {
+				saveOnFailure(result, generatedFilename, artifactName)
+			}
+
+			roundtrip, err := bookkeeping.LoadGenesisFromFile(generatedFilename)
+			require.NoError(t, err)
+
+			expected, err := bookkeeping.LoadGenesisFromFile("resources/" + artifactName)
+			saveOnFailure(assert.NoError(t, err))
+
+			blotOutRandomValues(expected.Allocation)
+			blotOutRandomValues(roundtrip.Allocation)
+			saveOnFailure(assert.Equal(t, expected, roundtrip))
+		})
+	}
 }

--- a/gen/generate_test.go
+++ b/gen/generate_test.go
@@ -180,7 +180,7 @@ func TestGenesisJsonCreation(t *testing.T) {
 		}
 	}
 
-	saveGeneratedGenesisJson := func(filename, artifactName string) {
+	saveGeneratedGenesisJSON := func(filename, artifactName string) {
 		src, err := os.Open(filename)
 		require.NoError(t, err)
 		defer src.Close()
@@ -198,7 +198,7 @@ func TestGenesisJsonCreation(t *testing.T) {
 	// Since `t.TempDir` deletes the generated dir, retain generated `genesis.json` on test failure.
 	saveOnFailure := func(result bool, generatedFilename, artifactName string) {
 		if !result {
-			saveGeneratedGenesisJson(generatedFilename, artifactName)
+			saveGeneratedGenesisJSON(generatedFilename, artifactName)
 			t.FailNow()
 		}
 	}

--- a/gen/resources/genesis-balance.json
+++ b/gen/resources/genesis-balance.json
@@ -1,0 +1,290 @@
+{
+  "alloc": [
+    {
+      "addr": "7777777777777777777777777777777777777777777777777774MSJUVU",
+      "comment": "RewardsPool",
+      "state": {
+        "algo": 100000,
+        "onl": 2
+      }
+    },
+    {
+      "addr": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+      "comment": "FeeSink",
+      "state": {
+        "algo": 100000,
+        "onl": 2
+      }
+    },
+    {
+      "addr": "LL5I5MBVV6LU26ENXVZ733A3IKUUTYMG6ZRCJB7G4GZIPSVFPHCCK2YKME",
+      "comment": "Wallet1",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "Tk6dVeLp2jkpR4GqTkUqmg4b7wwkgYshXpQ6FvWkJbQ=",
+        "vote": "DMXQB3LRyCznSDwFY7QhG+v6vrhaRR5DmcVBkiojGAw=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "LMSUTQYZ6PVSFF2UC2Y5BQQ6BPZPEEP4TJDZZAFGWFD7NR6JUIWYOBB7FA",
+      "comment": "Wallet10",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "FGmOjAOiA5WS36RbQqgW0R8+/7hNhr4d01w57E2Rj98=",
+        "vote": "rwRNmKNCR21GR7fGx0JscZFxAqDDntddmGPBrcPM3uM=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "IRLTNUT6N4RJPWHKHTGEFCC7XZPYXWUEQ3KPQDIPDOM4QCHMERLDCKB5BA",
+      "comment": "Wallet11",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "o3HGYpY+Cgon0G8h+LXt+x51iblyDAjU+UVh3i83QE0=",
+        "vote": "OisiREqsWPCCp/DQAAv/zv3t1cZuk9/EpHFTge45n9g=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "BL6N224XD2AO3UFAL3FYT4XV6TT225THQN2WZEVK2SZ2EN65MOWKOUHPCE",
+      "comment": "Wallet12",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "9t88h4TvAKqMIlRoLW9lfEIUZHkkeTeZNkxhf6cwBk4=",
+        "vote": "M2t4hO2Oe2cM0luPVQQjKFJUdUAve//NJLu31+AjSf8=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "7QAXF4XTPDNNP7IQXY2GAPU54SWOAEYN3KFNYZNYIT2TGTIATQYVYX34EE",
+      "comment": "Wallet13",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "EDectK5ACzkRBdTaK2jTJ3p2LRWVdIr2yqhw7vgLBAQ=",
+        "vote": "bD/yb+z+7TenZqd0G950WdDibXWcnH+5tLAUx6UWG28=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "EMOKFY3CUL5N63QL3K35AED5V23GLHFOCK247DW352NJQ2L7RX67TXBKLI",
+      "comment": "Wallet14",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "gFAz62RY4LPBD2TYmkKkm3RM0sE7kDH7XsA2nTjEMxU=",
+        "vote": "ZgVdTpahN5PgVcTsmNoLW8clsoHne2nfXnx7+jHbAeI=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "VHPOCATOURTR5Q4CCCSHFMDED2DJNQOSHIK5ZYRTWWXQ2NQHIFVVKC7IGM",
+      "comment": "Wallet15",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "faGqWez33n/hffAoQb1Mhiveb4SraHFUaXeBSTbDvtY=",
+        "vote": "i77hs2kcwF02SElbT7Bz9Pf75IYgF5nhqxhd8nQZ1y8=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "ZRTQWKBBNEGRYFDGVLVSI3FJHKIBQ7K527IWKXH75VTFCXMZVZGD4XA75E",
+      "comment": "Wallet16",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "0lQOFHTrORZmsJaFi3VbWtQM3eqIQuYtSiWm4UFI0/I=",
+        "vote": "mNQRvebWl6fHaO2icPtI4jv62UuaZXRFlz6PUvSXLjI=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "MFS6B3P3R7FOKMAU4FLMMMOKQVWTZCFYKEPE6SW66A5OJDWFFRFPMSO6AU",
+      "comment": "Wallet17",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "XKWnu0OXX1IaFYpm+IB00UXN83ap2d3uJqoSygqQyZE=",
+        "vote": "owK+kZlEr0VuFJZJMslXwpWHbnOdvRxQWLB3N4jpRt0=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "OLUNBJRRR2N4RSLIYNKAQNJIW7FK7M23AOPMIHER6RECHMGUINAV2WAXYA",
+      "comment": "Wallet18",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "c0Fku3FF4VxiDPxdTJ30+aoR9UdPkQ/iDV0DiKLjCh0=",
+        "vote": "eNwVkHYORjGE1Qme1D9o842cgFAn4nidryN35CgK78s=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "7VQYT4PAQBABDR3QODW5MUB3RU6MQ5MIWVIUR2HN3CSPA5H64TVQY4NT64",
+      "comment": "Wallet19",
+      "state": {
+        "algo": 400000000000000,
+        "onl": 1,
+        "sel": "TlelrGjnKdubOuRRMo2Mum2uUAP6UkG2ANDD+BZKOTo=",
+        "vote": "LWlAr9lRXcolQ9h4fX2DTw3LU8/KI6Eix6tJ+o8fsho=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "BSJ5G7YEOVTEKKDJZZKULAJPBH26SPIV4RJLV5AUSYZ36ELRN3JHZTZX2E",
+      "comment": "Wallet2",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "D3aE+VywLz4HA8NPX7mEB3m33FOer4L2ZBRa0qT/1fI=",
+        "vote": "ITColZ7Roe/p+qQXX8yk6FKibhN6sShNWFdvgDk3kGY=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "ETMCXHLEI7KOTMPVIOZAAPMQGQTST3CPZP4YG25HBCFB6XY3IIGH3YYUSE",
+      "comment": "Wallet20",
+      "state": {
+        "algo": 400000000000000,
+        "onl": 1,
+        "sel": "4Hg5XgcvEQsPiI7eaNE3hZgKZIvBl93CCKZZ8GZIDps=",
+        "vote": "HOecVUnX8xe86+Rrt237Z+jXFILhBM2I7GvyxCWxpbY=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "TQYRDSG5BS5XR6USGROXP5DSUAHJHKUTE5GBLENHBGWKAK2YNLEANQ7ELM",
+      "comment": "Wallet3",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "hOfLlBV0eDcF1lV7cUxMfo7dKBmCBflrgNJ1NxDv1KQ=",
+        "vote": "AgpySx7yp2177QjUueEJ+HN1xpQTW8Uf6sTu6lCHq2w=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "BOKSOEFFJE4RUPFMZHPQRJBEORY3W5BJNR5YUEYGOWKN6IZP4XLMHPLBCQ",
+      "comment": "Wallet4",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "arO4hIghNSwWvmr+hNHItYFniImOiCjGo4IwPDEBENg=",
+        "vote": "QLeClCU8nw2hHPA9YnrhWSlZ0Nc5awyk5WI/RhipGrU=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "VIMND5G6N6BYICGLXPBBKJNOO36K22HHUDV4KCKOS2STO225AKKGWNLOOM",
+      "comment": "Wallet5",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "sTAHT53hHEAMC/NXj+N6sAXvBrJzIU3QeIiD8YdyHN8=",
+        "vote": "qXu3+DUAPs71xZtugIxYOOFh4pxQ1zOD/wDvACmNAOo=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "6GQNPBPISA6YUSLIHCKFGNARGA36PPFEI3G77MVFZRLBB5T7ENOFLUIOM4",
+      "comment": "Wallet6",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "DVqDBjuBNwqDgn/Srl0M0iAhY4F7OaYlPM6Mksqag7s=",
+        "vote": "wwy76l2W220L/T7NxYu0RwkCtgZopwAby7+Ufo3FroE=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "HLBHM4N2YBRERHGBRMSBJ2H374X3UGLPB3EFGQ42P5HJ3AGOZPBZMNLHWI",
+      "comment": "Wallet7",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "HLNbmSEJe1ToTIT6QJ7xymrJlC9DPX00Ebw3MMyKb9Q=",
+        "vote": "D4+2cKNIhuAv0Rum9x5Tw5RT1/SsmuPpuxB8eQ4OrS8=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "M5O226M5GLGRHVQ3CWFFZBFUB4GPLK7RPSCGU25VY2Z5STSQI6D7LLXCQE",
+      "comment": "Wallet8",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "HgmAAyQuxjdD5dYW6QORoKL756+8PLfFckbtEtd6Qms=",
+        "vote": "+2NoVf0UHCM6+xf2crgh03vXHW4/rvJbvV1kgU6eb8A=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "66UUTNSIJMQJRM7GPNBDBNWQSLPDRX5MFRZYZDDILCATHB6EWFZVJEGC5M",
+      "comment": "Wallet9",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "74oS0XpjjqpTB+6nKj0bMl4ZMHN5HLvpSCnczSfkX0Q=",
+        "vote": "BWTZ9sJJVzjo20iFWBeCTrc1nxETWHP1IBAzjR+TtC8=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "HHDJTAQXM35CDYBVD5YB3ZYXZ3SA2G7EPX377CLYWSA4OAQTQ3JLS7GJJQ",
+      "comment": "bank",
+      "state": {
+        "algo": 100000000000000,
+        "onl": 1,
+        "sel": "UMIH8ldIewQ9K0dKs1iWIwLBNsS2+9GEaZh7/wkvPmI=",
+        "vote": "MSgY48yyvE+XHdeJGj7Muh17rn+JqNt0NMtzOBCM4yU=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "IVRXBBY53IKQW4I5M7CYRCE6W37TYIB4IIR73KBDWTROMVAOGPT5K75E3Y",
+      "comment": "pp1",
+      "state": {
+        "algo": 50000000000000
+      }
+    },
+    {
+      "addr": "UDMWNUYTV4AU6Y76RCNHMTWVZ6QYACYFJP4PAZNBMRWRFZKRNE6V7SBG7Q",
+      "comment": "pp2",
+      "state": {
+        "algo": 50000000000000
+      }
+    }
+  ],
+  "fees": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+  "id": "v1.0",
+  "proto": "https://github.com/algorand/spec/tree/a26ed78ed8f834e2b9ccb6eb7d3ee9f629a6e622",
+  "rwd": "7777777777777777777777777777777777777777777777777774MSJUVU"
+}

--- a/gen/resources/genesis-base.json
+++ b/gen/resources/genesis-base.json
@@ -1,0 +1,290 @@
+{
+  "alloc": [
+    {
+      "addr": "7777777777777777777777777777777777777777777777777774MSJUVU",
+      "comment": "RewardsPool",
+      "state": {
+        "algo": 125000000000000,
+        "onl": 2
+      }
+    },
+    {
+      "addr": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+      "comment": "FeeSink",
+      "state": {
+        "algo": 100000,
+        "onl": 2
+      }
+    },
+    {
+      "addr": "5P7SSF6IRMBZKQBH4KJLZMKNK3VB5SHK3ZEUJAUD4NODLLXJLOCJPY6GWA",
+      "comment": "Wallet1",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "R3ZILpY0ZOgcRbb3spZyXBtwt4Q9oeP4JkGmLWvp1wM=",
+        "vote": "fjzsjb8BcM4KhDPQyf7qxisv8mWzb6t+nv9eZnPbq3w=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "23PVZMF53OVWQ5YRJDG75P774AAQDOWMGT2YRRO3ZVCAMV7P6WQDUHTHSY",
+      "comment": "Wallet10",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "M/NhvAm8FfFxgcEynZ2XyiedqA0ZXsYPpQAT9j8UStg=",
+        "vote": "3QrVWdEk/JU5+W3KsOqZQWwqBP+3syw3jWkra5UlRyY=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "5GWNQULH2QB7IAMX7XAIYU6VQT7S4JTZZE2MVCO7HNWGFHM6GTGUCFVEIY",
+      "comment": "Wallet11",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "lEHWhsPoBlboeK+m9ASMV+eHe6aMWFr2wDFtW7BhZps=",
+        "vote": "m9hkZTh3JZtipCgRMQlxvjLHEBlPWI5rzi0a62nYmn4=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "MXEYXXM74MXMOJ7VCDDHYUIDELZBLETSB6ZUCR2K4OLCFKYPVBTJ7Q3WXA",
+      "comment": "Wallet12",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "dRgwg+/Q0WhqJu4pzVmFN15czLEwpzGbFHnqsGktRjk=",
+        "vote": "idEmvipGvNuebDonCSLcFJhaxjpft/1MZqxGzM0MOnY=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "MDPD6UI4D7CRJO2QP3OA4GJAZXMGE5LY5XV2FQ36RJ5MKKRLNT3NPXFM4Y",
+      "comment": "Wallet13",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "teFS7YWTutxUvxSWXHzuS8wwkX5ueR9CEanNR0IhsHM=",
+        "vote": "FpRYYVxA2I72a0m3+bJ+4fzD+wcsgRbMXzPrX+ihZKo=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "NW3ARRUBZDSTXH5FXI54LZUATS5QHYZGQHONXJFZWUQCU6EYVM57KQCSGU",
+      "comment": "Wallet14",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "3vwiEtd2C0wm89P9vex9nud8nM4rdgCd8OAT7SUWfpA=",
+        "vote": "dXoHsQvvUY6HiRIR2JUaTFR21RROq+tzA3ApYL8lw7I=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "54Q7QENDL6GRX7XOBONV3AY2OHD62IGQPEFNUCKL4IH6XD2HGSJETIR22Y",
+      "comment": "Wallet15",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "b0hfKTC81csTjO/x21E6w4OpDlcVNCZBWky0gwpo2qo=",
+        "vote": "T9UBwWaOpUnq4azO1yyaH8rTHWXzfanIHib0RxI9N+c=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "DU4LJRJKBIIREB7CKKWCOUP6NHUM5HKKVYH6LU2ZE63D67PZRL7VSHNADI",
+      "comment": "Wallet16",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "JIdWGPjyKJZCfC5Y+IYxqC1oDEa2pXePQ3TSBQ3v+K0=",
+        "vote": "nYIVrFrNAf4lWvt1RiLR2Nv/EzaxH5us/7prSQqbFgM=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "Z745PXKLO7EJOBMUYKMZQXZJQD2NOI2ZC5CUUVZYQDL6S5FCMG2RTDR43U",
+      "comment": "Wallet17",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "29+iADCFdA+wltMu0ZgCPzAogbbp5kr5zRRJteB2mdE=",
+        "vote": "vzXs2Ebue388Ya3vVgEZ2JX6IJaZuIn2MIcl1N1T0lk=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "PA2FWPXRLKGKDRTP5JFYWWM3PBE77SINTRZ5BQCCKAK363TMMVFUJOM3OA",
+      "comment": "Wallet18",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "fKYC8BIRXI/4s0E52wDYd0jSiOgvStdA+8Vr7fTh0TA=",
+        "vote": "+jaGxdKU5PpxQxp7XRCYhc0Oss6josumZW7GNhl9Kkg=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "R24KUNIHRTSDYEWVJVJMHJ2IYE3NXBTSE3NQXOHPG5ULJJ4YEP6DXLWIQM",
+      "comment": "Wallet19",
+      "state": {
+        "algo": 400000000000000,
+        "onl": 1,
+        "sel": "J1yWsrjAlqi0/HXQ++yK03+iFuPPu9q0HZVWp2V5gjU=",
+        "vote": "db7v7DZeGSeI9t3eXXoO0DxMghAGmidVh3bGBOeqcC8=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "WLEX5HDAKMEA35NKY2QUXFXIFIKMOF6PHLMNDD25KLNNTPXRRO7TPAP6SQ",
+      "comment": "Wallet2",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "AYda5HHpJpFnpbQ/oeqvc9eSKPccHldGczvqwsJzWiE=",
+        "vote": "HjXz+GAo7yqeKRsOB+RQNr2V5vjwS/bMynMTr37T8D8=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "XSQO4QZQZLFSAM7GOGYIOFH3EKTYC3WVO3CND7V4QQ7KXOQBD2OYRCCARE",
+      "comment": "Wallet20",
+      "state": {
+        "algo": 400000000000000,
+        "onl": 1,
+        "sel": "joC7f9011hnDVa87WsaRSD/+Z8HyJ6tPT8NCQJJKNQ4=",
+        "vote": "BRVqGnSjJZnBM2MdHs3YkApVB9iR6nd6VVTx2kvPQjw=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "KE2HQAZHGJDKZUKRBDBQTBQOSVSCDROUC7UFJZ27KTNHBKON6GKFBDD5MY",
+      "comment": "Wallet3",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "lb/5w4Q/6KE3g2+KeRc4GrslWubT/2QkKQX9pJqBwWA=",
+        "vote": "gs5MFqUUn/IDBb0kb4VJiv6gIOUVIcSSmpdaLteAKmw=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "7SCSRGS3YLKORJLJI6AGJOBEQYOVEMCPF52F3TK6KZZRZVZQCKCFGOGWIY",
+      "comment": "Wallet4",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "ImC3tocbWRoTdd90owSbskgsvnNpyFW1c79CNJl2mjU=",
+        "vote": "xFrT7tp0Yth3j39XJJKtKxxMaXDiFRbXtzoOjQnavFY=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "2FCYNSOOK6HGVK4ZJZ3ROAV6S3Y6KYY5467BY7JQEVTT75RNSIM3D6WK5M",
+      "comment": "Wallet5",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "aEKSz4Hqi6JY82890qxqAUhkiQ2YvDYNrQBjq6UOgwU=",
+        "vote": "Gxyf2lPDSVhLrfUOtS6vS0fvrV9g22XHR/uUl7uzzsw=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "6SUHM22SBOZ4O4E7VQIB2FWHGCFLBCDOZAQ6AWXV3CTEDVB45UZGX2GZ2U",
+      "comment": "Wallet6",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "OXOkW9CbraU2UM1IjDkkpS3zGlBCjm0SHc3mFgZrUdE=",
+        "vote": "ssh7jRwaim+vTO4W9F2tw+j5BoFOqTTTy1DOZfqIXwY=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "H2A6ALQ6U7P2JSABWPRLG3IRRKH3AAUJFZXLI7YHCBZ7K6DOTHWBVGFIZM",
+      "comment": "Wallet7",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "B9rVwMkp9YAbdOz3vOK2K7UyDBsHBGeHUEcErioligA=",
+        "vote": "MyheCHyiz464tL3rdZkztIl/fx7ARYPvEv8xuFozCfM=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "5ZBBKATPM6HM56TOGQOSPFMIOVUZJJAZAAUATNPVCB6SKQYVIMRUOC454Q",
+      "comment": "Wallet8",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "g/995Lmd4y+IhbDCD6CXLyuIMs+GhFbXbmvVSCwG9RU=",
+        "vote": "SJ0Hj+Xau09OB97nfbktnTnA5K4MqRzQCwDR1BN4R+8=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "UPL2Q6OLQHLAZWXBEP7DTN3225ISOJ45DACXEDCNJ2UBCPR7EWUCPMW3KE",
+      "comment": "Wallet9",
+      "state": {
+        "algo": 500000000000000,
+        "onl": 1,
+        "sel": "X8Df4E1SSkCEoWYfDOGMPTSoecc6FaHTzDRNYpOVL7I=",
+        "vote": "ZUkY2tLQ3XmcG6aVWjJLdJvWjWfoPI7EliAq/ZYaIUg=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "N6TENNVOWAILNAZIOT3RFX6C4DPC2HEYOQD5KBBGFDE77FUNZU7NMWBIKA",
+      "comment": "bank",
+      "state": {
+        "algo": 100000000000000,
+        "onl": 1,
+        "sel": "vBIkGS3JImg7DVRGr6L3ZLuzFe9EXSDedvZkHRgAGEQ=",
+        "vote": "NoVimVCKTiIntOa/q9zUcVEN5erCIdD0c5G2eIAzBL4=",
+        "voteKD": 10000,
+        "voteLst": 10
+      }
+    },
+    {
+      "addr": "XHV5PYJARUBZA6EMG6ERYAL4ROXVTLVHMC2W52LDGVOVQNCQOAFNLTG32U",
+      "comment": "pp1",
+      "state": {
+        "algo": 50000000000000
+      }
+    },
+    {
+      "addr": "4EDQJQLPFX5CBWHJJ2GQXKMV6UQC2O553PGZVID6QVB7JZT3XBQ5MCSD2Q",
+      "comment": "pp2",
+      "state": {
+        "algo": 50000000000000
+      }
+    }
+  ],
+  "fees": "A7NMWS3NT3IUDMLVO26ULGXGIIOUQ3ND2TXSER6EBGRZNOBOUIQXHIBGDE",
+  "id": "v1.0",
+  "proto": "https://github.com/algorand/spec/tree/a26ed78ed8f834e2b9ccb6eb7d3ee9f629a6e622",
+  "rwd": "7777777777777777777777777777777777777777777777777774MSJUVU"
+}

--- a/gen/walletData.go
+++ b/gen/walletData.go
@@ -50,7 +50,7 @@ type GenesisData struct {
 	Wallets            []WalletData
 	FeeSink            basics.Address
 	RewardsPool        basics.Address
-	RewardsPoolBalance uint64
+	RewardsPoolBalance uint64 // Values < `ConsensusParams.MinBalance` are adjusted to `ConsensusParams.MinBalance`
 	DevMode            bool
 	Comment            string
 }


### PR DESCRIPTION
Extends https://github.com/algorand/go-algorand/pull/4643 with a test confirming `RewardsPoolBalance` override < min balance produces the intended `genesis.json`.

Notes:
* Rather than assert on each property of interest, the PR's approach is to record a well-formed `genesis.json` and compare it against a newly generated `genesis.json`.  Since there's a large number of properties to confirm are unchanged, I felt comparing artifacts is a better tradeoff.  I can elaborate on the rationale as needed.
* Deletions in `gen/generate.go` occur because I visually confirmed the state is _not_ used.  Since tests pass before + after the change, I feel confident it's _safe_.